### PR TITLE
Add Node-based tests for money formatting

### DIFF
--- a/__tests__/theme.test.ts
+++ b/__tests__/theme.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+const { money } = require('../money');
+
+test('formats zero amount in USD', () => {
+  assert.strictEqual(money(0), '$0.00');
+});
+
+test('formats amount in EUR with de-DE locale', () => {
+  assert.strictEqual(money(12345, 'EUR', 'de-DE'), '123,45\u00A0€');
+});

--- a/money.ts
+++ b/money.ts
@@ -1,0 +1,2 @@
+export const money = (amountCents: number, currency = 'USD', locale = 'en-US') =>
+  new Intl.NumberFormat(locale, { style: 'currency', currency }).format((amountCents || 0) / 100);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "npx tsc -p tsconfig.test.json && node --test dist/__tests__/theme.test.js"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",

--- a/theme.ts
+++ b/theme.ts
@@ -1,4 +1,5 @@
 import { useColorScheme } from 'react-native';
+export { money } from './money';
 
 export const palettes = {
   light: {
@@ -32,6 +33,3 @@ export function useTheme() {
   const c = palettes[scheme];
   return { scheme, colors: c };
 }
-
-export const money = (amountCents: number, currency = 'USD', locale = 'en-US') =>
-  new Intl.NumberFormat(locale, { style: 'currency', currency }).format((amountCents || 0) / 100);

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2019",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "types": ["node"],
+    "skipLibCheck": true
+  },
+  "include": ["money.ts", "__tests__/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- configure npm test script using TypeScript compiler and Node's built-in test runner
- add reusable `money` formatter utility and re-export from theme
- add unit tests for `money` covering USD and EUR formatting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895ca3765b883208f5309dbddb1eb83