### PR TITLE
chore: clean up unused imports

### DIFF
--- a/app/(tabs)/create-offer.tsx
+++ b/app/(tabs)/create-offer.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import {
-  View, Text, TextInput, StyleSheet, TouchableOpacity, Alert,
+  Text, TextInput, StyleSheet, TouchableOpacity, Alert,
   ScrollView, Image, ActivityIndicator, KeyboardAvoidingView, Platform
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   View, Text, StyleSheet, TextInput, TouchableOpacity, Image, Alert, ActivityIndicator, ScrollView
 } from 'react-native';


### PR DESCRIPTION
## Summary
- remove unused View import from create offer screen
- drop unused useMemo import from profile screen

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895d20feb508320b06e1ac0bb4f8d9b