### PR TITLE
fix: enable partner access request

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -141,13 +141,19 @@ export default function Profile() {
     if (!user) return;
     setLoading(true);
     try {
-      await setDoc(doc(db, 'partnerRequests', user.uid), {
-        uid: user.uid,
-        email: user.email ?? null,
-        displayName: user.displayName ?? null,
-        createdAt: new Date(),
-        status: 'pending',
-      });
+      await setDoc(
+        doc(db, 'users', user.uid),
+        {
+          partnerRequest: {
+            uid: user.uid,
+            email: user.email ?? null,
+            displayName: user.displayName ?? null,
+            createdAt: new Date(),
+            status: 'pending',
+          },
+        },
+        { merge: true }
+      );
       Alert.alert('Request sent', 'We will review your partner request.');
     } catch (e: any) {
       Alert.alert('Failed', e?.message ?? 'Try again');


### PR DESCRIPTION
## Summary
- store partner request inside the user's document to avoid Firestore permission errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895d24c9e008320b0f2b68c7e58890e