### PR TITLE
Add scheme config and adjust bookings query

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,8 @@
 {
-  "plugins": [
-    "expo-router"
-  ]
+  "expo": {
+    "scheme": "leftoversaver",
+    "plugins": [
+      "expo-router"
+    ]
+  }
 }

--- a/app/(tabs)/orders.tsx
+++ b/app/(tabs)/orders.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, StyleSheet } from 'react-native';
 import { auth, db } from '../../firebase';
-import { collection, onSnapshot, orderBy, query, where } from 'firebase/firestore';
+import { collection, onSnapshot, query, where } from 'firebase/firestore';
 
 type Booking = {
   id: string;
@@ -19,12 +19,14 @@ export default function Orders() {
     if (!uid) return;
     const q = query(
       collection(db, 'bookings'),
-      where('uid', '==', uid),
-      orderBy('createdAt', 'desc')
+      where('uid', '==', uid)
     );
-    const unsub = onSnapshot(q, (snap) =>
-      setBookings(snap.docs.map(d => ({ id: d.id, ...(d.data() as Omit<Booking, 'id'>) })))
-    );
+    const unsub = onSnapshot(q, (snap) => {
+      const docs = snap.docs
+        .map(d => ({ id: d.id, ...(d.data() as Omit<Booking, 'id'>) }))
+        .sort((a, b) => (b.createdAt?.seconds ?? 0) - (a.createdAt?.seconds ?? 0));
+      setBookings(docs);
+    });
     return unsub;
   }, [uid]);
 


### PR DESCRIPTION
## Summary
- define custom URL scheme in Expo config for linking
- remove Firestore orderBy and sort bookings locally to avoid index requirement

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895d34918dc8320b477d581a44887de