### PR TITLE
Add mock offer data and Firestore seeding script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ npm run reset-project
 
 This command will move the starter code to the **app-example** directory and create a blank **app** directory where you can start developing.
 
+## Seed mock offers
+
+To populate your Firestore instance with sample offers for testing, run:
+
+```bash
+node scripts/seed-mock-offers.mjs
+```
+
+This uses the data defined in [`scripts/mock-offers.json`](scripts/mock-offers.json) and writes it to the `offers` collection in your Firebase project.
+
 ## Learn more
 
 To learn more about developing your project with Expo, look at the following resources:

--- a/scripts/mock-offers.json
+++ b/scripts/mock-offers.json
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "Cafe Aroma Surprise Bag",
+    "priceCents": 599,
+    "currency": "EUR",
+    "pickupUntil": "Pickup before 8PM",
+    "stock": 5,
+    "lat": 52.52,
+    "lng": 13.405,
+    "imageUrl": "https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=600&q=60",
+    "ownerUid": "demoCafeAroma"
+  },
+  {
+    "name": "Downtown Bakery Bread Bundle",
+    "priceCents": 399,
+    "currency": "EUR",
+    "pickupUntil": "Pickup 6–7PM",
+    "stock": 3,
+    "lat": 52.519,
+    "lng": 13.401,
+    "imageUrl": "https://images.unsplash.com/photo-1608198093002-ad4e0054848b?auto=format&fit=crop&w=600&q=60",
+    "ownerUid": "demoBakery"
+  },
+  {
+    "name": "Sushi Palace Leftover Box",
+    "priceCents": 1099,
+    "currency": "EUR",
+    "pickupUntil": "Pickup before 9PM",
+    "stock": 2,
+    "lat": 52.515,
+    "lng": 13.409,
+    "imageUrl": "https://images.unsplash.com/photo-1562967916-eb82221dfb36?auto=format&fit=crop&w=600&q=60",
+    "ownerUid": "demoSushiPalace"
+  }
+]

--- a/scripts/seed-mock-offers.mjs
+++ b/scripts/seed-mock-offers.mjs
@@ -1,0 +1,34 @@
+import { initializeApp } from 'firebase/app';
+import { getFirestore, collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import { getAuth, signInAnonymously } from 'firebase/auth';
+import mockOffers from './mock-offers.json' assert { type: 'json' };
+
+const firebaseConfig = {
+  apiKey: "AIzaSyC9aQyaasujxcB2DArKwanr-o0PYR9MRd4",
+  authDomain: "leftoversaver-bb248.firebaseapp.com",
+  projectId: "leftoversaver-bb248",
+  storageBucket: "leftoversaver-bb248.appspot.com",
+  messagingSenderId: "11219079849",
+  appId: "1:11219079849:web:e97fd987adcbeefeb20fb8",
+};
+
+async function seed() {
+  const app = initializeApp(firebaseConfig);
+  const db = getFirestore(app);
+  const auth = getAuth(app);
+  await signInAnonymously(auth);
+
+  for (const offer of mockOffers) {
+    await addDoc(collection(db, 'offers'), {
+      ...offer,
+      createdAt: serverTimestamp(),
+    });
+  }
+
+  console.log(`Seeded ${mockOffers.length} offers`);
+}
+
+seed().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `scripts/mock-offers.json` with sample offer entries
- add `scripts/seed-mock-offers.mjs` to load mock offers into Firestore
- document seeding process in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895d675aa9c8320bc0122032e07b72f