### PR TITLE
chore: add expo auth session dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.24",
     "expo": "~53.0.20",
+    "expo-auth-session": "~6.2.1",
     "expo-blur": "~14.1.5",
     "expo-constants": "~17.1.7",
     "expo-font": "~13.3.2",


### PR DESCRIPTION
## Summary
- include `expo-auth-session` so profile screen can import Google provider

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895d86f08148320b2a1ea6fab6d0af7