### PR TITLE
feat: add notification support

### DIFF
--- a/app/(tabs)/create-offer.tsx
+++ b/app/(tabs)/create-offer.tsx
@@ -7,6 +7,7 @@ import * as ImagePicker from 'expo-image-picker';
 import { router } from 'expo-router';
 import { auth, db, storage } from '../../firebase';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import { notifyNewOffer } from '../../notifications';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 
 export default function CreateOffer() {
@@ -90,7 +91,7 @@ export default function CreateOffer() {
         ownerUid: auth.currentUser.uid,
         createdAt: serverTimestamp(),
       });
-
+      await notifyNewOffer(name.trim());
       Alert.alert('Created', 'Offer added successfully.', [
         { text: 'OK', onPress: () => router.back() },
       ]);

--- a/app/(tabs)/details.tsx
+++ b/app/(tabs)/details.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity, Alert, ActivityIndicator } fr
 import { useLocalSearchParams, router } from 'expo-router';
 import { auth, db } from '../../firebase';
 import { addDoc, collection, doc, runTransaction, serverTimestamp } from 'firebase/firestore';
+import { scheduleBookingReminder } from '../../notifications';
 import { money } from '../../theme';
 
 type Offer = {
@@ -48,6 +49,7 @@ export default function Details() {
         });
       });
 
+      await scheduleBookingReminder(data.pickupUntil);
       Alert.alert('Booked!', 'Your meal has been reserved.', [
         { text: 'OK', onPress: () => router.replace('/(tabs)/orders') },
       ]);

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,7 +1,8 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { View, Text, Animated, FlatList, TouchableOpacity, Dimensions, StyleSheet, Image, StatusBar } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { router } from 'expo-router';
+import { registerForPushNotificationsAsync } from '../notifications';
 
 const { width, height } = Dimensions.get('window');
 
@@ -36,6 +37,10 @@ const slides: Slide[] = [
 const OnboardingScreen: React.FC = () => {
   const scrollX = useRef(new Animated.Value(0)).current;
   const flatListRef = useRef<FlatList<Slide>>(null);
+
+  useEffect(() => {
+    registerForPushNotificationsAsync();
+  }, []);
 
   const handleSkip = () => {
     router.replace('/(tabs)/home'); // or '/(tabs)/home' for home tab directly

--- a/notifications.ts
+++ b/notifications.ts
@@ -1,0 +1,87 @@
+import * as Notifications from 'expo-notifications';
+import Constants from 'expo-constants';
+import { collection, doc, getDocs, setDoc } from 'firebase/firestore';
+import { auth, db } from './firebase';
+
+// Display notifications when the app is foregrounded
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: false,
+    shouldSetBadge: false,
+  }),
+});
+
+/**
+ * Request notification permissions and register the device for push
+ * notifications. The expo push token is saved in Firestore so that the
+ * backend can send targeted messages later on.
+ */
+export async function registerForPushNotificationsAsync(): Promise<string | null> {
+  try {
+    const { status } = await Notifications.requestPermissionsAsync();
+    if (status !== 'granted') {
+      return null;
+    }
+
+    const tokenData = await Notifications.getExpoPushTokenAsync({
+      projectId: Constants.expoConfig?.extra?.eas?.projectId,
+    });
+    const token = tokenData.data;
+
+    // Store the token either under the user document or in a tokens collection
+    const uid = auth.currentUser?.uid;
+    if (uid) {
+      await setDoc(doc(db, 'users', uid), { pushToken: token }, { merge: true });
+    }
+    await setDoc(doc(db, 'tokens', uid || token), { token }, { merge: true });
+
+    return token;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Schedule a local reminder to pick up the booked meal. Currently this simply
+ * fires an alert one hour from now with the provided pickup window text.
+ */
+export async function scheduleBookingReminder(pickupUntil: string) {
+  const trigger = new Date(Date.now() + 60 * 60 * 1000); // one hour from now
+  await Notifications.scheduleNotificationAsync({
+    content: {
+      title: 'Meal pickup reminder',
+      body: `Remember to pick up your meal. ${pickupUntil}`,
+    },
+    trigger,
+  });
+}
+
+/**
+ * Notify all registered devices about a newly created offer.
+ */
+export async function notifyNewOffer(offerName: string) {
+  const snap = await getDocs(collection(db, 'tokens'));
+  const tokens = snap.docs
+    .map((d) => d.data().token as string | undefined)
+    .filter((t): t is string => !!t);
+
+  if (tokens.length === 0) return;
+
+  const messages = tokens.map((token) => ({
+    to: token,
+    sound: 'default',
+    title: 'New offer available',
+    body: `${offerName} just dropped!`,
+  }));
+
+  await fetch('https://exp.host/--/api/v2/push/send', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(messages),
+  });
+}
+

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.10",
     "expo-web-browser": "~14.2.0",
+    "expo-notifications": "~0.29.5",
     "firebase": "^12.1.0",
     "lottie-react-native": "7.2.2",
     "react": "19.0.0",


### PR DESCRIPTION
## Summary
- add expo notifications utility for push tokens and reminders
- request permissions on onboarding
- schedule booking reminders and notify users of new offers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895f71e90b883208f1c52c08a1bbd84