### PR TITLE
Add booking codes and cancellation handling

### DIFF
--- a/app/(tabs)/details.tsx
+++ b/app/(tabs)/details.tsx
@@ -36,7 +36,8 @@ export default function Details() {
         const currentStock = (current?.stock ?? 1);
         if (currentStock <= 0) throw new Error('Sold out');
         tx.update(offerRef, { stock: currentStock - 1 });
-        // create booking
+        // create booking with unique code and status
+        const code = Math.random().toString(36).slice(2, 10).toUpperCase();
         await addDoc(collection(db, 'bookings'), {
           offerId: data.id,
           offerName: data.name,
@@ -44,6 +45,8 @@ export default function Details() {
           pickupUntil: data.pickupUntil,
           uid: auth.currentUser!.uid,
           createdAt: serverTimestamp(),
+          code,
+          status: 'active',
           ...(data.currency ? { currency: data.currency } : {}),
         });
       });

--- a/app/(tabs)/orders.tsx
+++ b/app/(tabs)/orders.tsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, FlatList, StyleSheet } from 'react-native';
+import { View, Text, FlatList, StyleSheet, TouchableOpacity, Alert } from 'react-native';
 import { auth, db } from '../../firebase';
-import { collection, onSnapshot, query, where } from 'firebase/firestore';
+import { collection, onSnapshot, query, where, doc, updateDoc } from 'firebase/firestore';
+import { money } from '../../theme';
 
 type Booking = {
   id: string;
   offerName: string;
   price: string;
   pickupTime: string;
+  code: string;
+  status: string;
   createdAt?: any;
 };
 
@@ -23,7 +26,18 @@ export default function Orders() {
     );
     const unsub = onSnapshot(q, (snap) => {
       const docs = snap.docs
-        .map(d => ({ id: d.id, ...(d.data() as Omit<Booking, 'id'>) }))
+        .map(d => {
+          const data = d.data() as any;
+          return {
+            id: d.id,
+            offerName: data.offerName,
+            price: money(data.priceCents, data.currency || 'EUR'),
+            pickupTime: data.pickupUntil,
+            code: data.code,
+            status: data.status,
+            createdAt: data.createdAt,
+          } as Booking;
+        })
         .sort((a, b) => (b.createdAt?.seconds ?? 0) - (a.createdAt?.seconds ?? 0));
       setBookings(docs);
     });
@@ -31,6 +45,14 @@ export default function Orders() {
   }, [uid]);
 
   if (!uid) return <View style={styles.center}><Text>Please sign in to view orders.</Text></View>;
+
+  const onCancel = async (id: string) => {
+    try {
+      await updateDoc(doc(db, 'bookings', id), { status: 'cancelled' });
+    } catch (e: any) {
+      Alert.alert('Cancellation failed', e.message ?? 'Please try again.');
+    }
+  };
 
   return (
     <View style={{ flex: 1, paddingTop: 60 }}>
@@ -43,6 +65,12 @@ export default function Orders() {
           <View style={styles.card}>
             <Text style={styles.name}>{item.offerName}</Text>
             <Text style={styles.meta}>{item.price} • {item.pickupTime}</Text>
+            <Text style={styles.code}>Code: {item.code}</Text>
+            {item.status === 'active' && (
+              <TouchableOpacity style={styles.cancel} onPress={() => onCancel(item.id)}>
+                <Text style={styles.cancelText}>Cancel</Text>
+              </TouchableOpacity>
+            )}
           </View>
         )}
       />
@@ -56,5 +84,8 @@ const styles = StyleSheet.create({
   card: { backgroundColor: '#fff', marginHorizontal: 16, marginVertical: 8, padding: 16, borderRadius: 14, elevation: 2 },
   name: { fontSize: 18, fontWeight: '700' },
   meta: { color: '#475569', marginTop: 4 },
+  code: { marginTop: 4, fontWeight: '600' },
+  cancel: { marginTop: 8, alignSelf: 'flex-start', backgroundColor: '#dc2626', paddingVertical: 6, paddingHorizontal: 12, borderRadius: 8 },
+  cancelText: { color: '#fff', fontWeight: '700' },
   center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
 });

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,17 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /bookings/{bookingId} {
+      allow read: if request.auth != null && request.auth.uid == resource.data.uid;
+      allow create: if request.auth != null &&
+        request.resource.data.uid == request.auth.uid &&
+        request.resource.data.status == 'active' &&
+        request.resource.data.code is string;
+      allow update: if request.auth != null &&
+        request.auth.uid == resource.data.uid &&
+        resource.data.status == 'active' &&
+        request.resource.data.status == 'cancelled' &&
+        request.resource.data.code == resource.data.code;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- generate unique code and `status` when creating a booking
- show booking code in orders and allow cancelling active bookings
- add Firestore rules to restrict booking updates and prevent reuse

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895f71f098c8320b59679074be06c5d