### PR TITLE
chore: remove invalid react-native-maps plugin

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,9 +1,6 @@
 {
   "expo": {
     "scheme": "leftoversaver",
-    "plugins": [
-      "expo-router",
-      "react-native-maps"
-    ]
+    "plugins": ["expo-router"]
   }
 }


### PR DESCRIPTION
## Summary
- remove react-native-maps from Expo plugins to avoid config error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896054b19408320a10bb61fda59a961