### PR TITLE
Add payment modal state to details screen

### DIFF
--- a/app/(tabs)/details.tsx
+++ b/app/(tabs)/details.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { auth, db } from '../../firebase';
@@ -36,6 +36,8 @@ export default function Details() {
   const data = useMemo(() => (offer ? JSON.parse(offer) as Offer : null), [offer]);
   const [loading, setLoading] = useState(false);
   const [store, setStore] = useState<Store | null>(data?.store ?? null);
+  const [showPayment, setShowPayment] = useState(false);
+  const paymentResolver = useRef<((paid: boolean) => void) | null>(null);
 
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
## Summary
- add state and resolver for `PaymentModal` to prevent `showPayment` reference errors in the details screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896072c5dbc8320acfd7031cb58705b