### PR TITLE
chore: add node types to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
+    "@types/node": "^22.7.6",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
     "typescript": "~5.8.3"


### PR DESCRIPTION
## Summary
- add `@types/node` to dev dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689609561ac48320a88f2080ba49be20