### PR TITLE
Add missing slider dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "@react-native-community/slider": "^4.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- add `@react-native-community/slider` dependency to resolve module resolution errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68960dd4706883208a0298115797bc05